### PR TITLE
Avoid crash if there are no settings saved

### DIFF
--- a/_config_vars.py
+++ b/_config_vars.py
@@ -94,7 +94,7 @@ class ConfigVars:
         """Loads stored settings."""
 
         loaded_str = config.get_str(self.__json_config_name)
-        if loaded_str is not None:
+        if loaded_str is not None and loaded_str != "":
             obj = json.loads(loaded_str)
             for m in self.__getJson2FieldMapper():
                 if m.json_name in obj:


### PR DESCRIPTION
Just check for an empty string so that JSON parser doesn't throw an exception