### PR TITLE
Improve compatibility with LandingPad plugin

### DIFF
--- a/cpp/drawables.h
+++ b/cpp/drawables.h
@@ -116,7 +116,7 @@ struct drawitem_t
     {
         // shape
         std::string shape;
-        std::string fill;
+        std::string fill = "none";
         int w{0};
         int h{0};
         font_size::FontPixelSize vector_font_size{0};

--- a/cpp/drawables.h
+++ b/cpp/drawables.h
@@ -354,6 +354,15 @@ inline draw_items_t parseJsonString(const std::string &src)
                 std::cout << "bad key: \"" << kv.key() << "\"" << std::endl;
             }
         }
+
+        // If the TTL is zero, the caller wants to remove the item. If they didn't specify the
+        // drawable type (which isn't necessary when removing something using its ID), we need to
+        // set the drawmode to something other than drawmode_t::idk, since that skips the rest of
+        // the rendering code.
+        if (drawitem.ttl.ttl == std::chrono::seconds::zero() && drawitem.drawmode == drawmode_t::idk) {
+             drawitem.drawmode = drawmode_t::text;
+        }
+
         if (drawitem.drawmode != draw_task::drawmode_t::idk || drawitem.isCommand())
         {
             if (drawitem.id.empty())

--- a/cpp/svgbuilder.cpp
+++ b/cpp/svgbuilder.cpp
@@ -277,7 +277,7 @@ void makeSvgShape(std::ostringstream &svgOutStream, const draw_task::drawitem_t 
     {
         svgOutStream << "<rect x='" << drawTask.x << "' y='" << drawTask.y << "' width='"
                      << drawTask.shape.w << "' height='" << drawTask.shape.h
-                     << "' fill='none' stroke='" << drawTask.color << "' stroke-width='"
+                     << "' fill='" << drawTask.shape.fill << "' stroke='" << drawTask.color << "' stroke-width='"
                      << kStrokeWidth << "' />";
     }
 }


### PR DESCRIPTION
The [LandingPad plugin](https://github.com/bgol/LandingPad) attempts to remove drawables by updating their TTL to zero. Since it just sends the ID and TTL, the overlay binary cannot determine what type of drawable (rectangle/svg/text/etc) it received and ignores it. This pull request adds a type into such drawables so the overlay can update and remove them.

This might be better implemented using a new type of drawmode_t::for_removal or somesuch, but I don't know enough c++ to get that working.

It also now passes on the fill colour to rectangles, which is also used by the LandingPad plugin.